### PR TITLE
refactor(test): flatMap() instead of map().flat()

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -126,7 +126,7 @@ async function invokeAndAwaitWorker(compName: string, workerName: string, functi
             "--component-name", compName,
             "--worker-name", workerName,
             "--function", functionName,
-            ...(functionArgs.map(arg => ["--arg", arg]).flat()),
+            ...(functionArgs.flatMap(arg => ["--arg", arg])),
         ],
     );
 


### PR DESCRIPTION
Instead of mapping then flattening the array, use the builtin flatMap function